### PR TITLE
Add script to download 10-year US stock financials

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
 # preparedness
+
+This repository contains a simple script to download the last 10 years of financial statements for a U.S. stock using the [Financial Modeling Prep](https://financialmodelingprep.com) API.
+
+## Requirements
+
+- Python 3
+- `requests` and `pandas` libraries
+
+Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+
+Run the script with a stock ticker symbol. For example, to fetch data for Apple (AAPL):
+
+```bash
+python extract_financials.py AAPL
+```
+
+CSV files containing the income statement, balance sheet, and cash flow statement will be saved in the current directory.

--- a/extract_financials.py
+++ b/extract_financials.py
@@ -1,0 +1,34 @@
+import requests
+import pandas as pd
+import sys
+
+API_URL = "https://financialmodelingprep.com/api/v3"
+API_KEY = "demo"  # Replace with your API key if available
+
+
+def fetch_financials(ticker: str, statement: str) -> pd.DataFrame:
+    url = f"{API_URL}/{statement}/{ticker}?period=annual&limit=10&apikey={API_KEY}"
+    response = requests.get(url)
+    response.raise_for_status()
+    data = response.json()
+    return pd.DataFrame(data)
+
+
+def main(ticker: str) -> None:
+    income = fetch_financials(ticker, "income-statement")
+    balance = fetch_financials(ticker, "balance-sheet-statement")
+    cash_flow = fetch_financials(ticker, "cash-flow-statement")
+
+    for name, df in [
+        ("income_statement", income),
+        ("balance_sheet", balance),
+        ("cash_flow", cash_flow),
+    ]:
+        df.to_csv(f"{ticker}_{name}.csv", index=False)
+
+    print(f"Financial statements saved for {ticker}")
+
+
+if __name__ == "__main__":
+    ticker = sys.argv[1] if len(sys.argv) > 1 else "AAPL"
+    main(ticker)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+requests
+pandas


### PR DESCRIPTION
## Summary
- add a small Python script (`extract_financials.py`) that downloads 10 years of US stock financial statements from the Financial Modeling Prep API
- document dependencies and usage in the README
- add `requirements.txt`

## Testing
- `pip install pandas`
- `python3 extract_financials.py AAPL` *(fails: Tunnel connection failed 403)*

------
https://chatgpt.com/codex/tasks/task_e_68430356563083248750b498e0798e17